### PR TITLE
fix: remove getContractEnv from cosmwasmAPI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/line/lbm-sdk v0.46.1-0.20230106043757-1ece23d83a0b
 	github.com/line/ostracon v1.0.7
-	github.com/line/wasmvm v1.1.1-0.11.1.0.20230414023914-cd1be91ce504
+	github.com/line/wasmvm v1.1.1-0.11.1.0.20230417075905-90cc1950b4a1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rakyll/statik v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -830,6 +830,8 @@ github.com/line/wasmvm v1.1.1-0.11.1.0.20230411020707-2c416761ae1a h1:7h6WnkxPCJ
 github.com/line/wasmvm v1.1.1-0.11.1.0.20230411020707-2c416761ae1a/go.mod h1:Lq3FVvi/rb+OOlTxqtcqcao2GGESQ4hUpuXMcjdJbco=
 github.com/line/wasmvm v1.1.1-0.11.1.0.20230414023914-cd1be91ce504 h1:4e/GalI4ApXzWmSOobb170NCM/f/kkklQkjy6YhsjvQ=
 github.com/line/wasmvm v1.1.1-0.11.1.0.20230414023914-cd1be91ce504/go.mod h1:Lq3FVvi/rb+OOlTxqtcqcao2GGESQ4hUpuXMcjdJbco=
+github.com/line/wasmvm v1.1.1-0.11.1.0.20230417075905-90cc1950b4a1 h1:0hVPU8sFOyP3Clht8FKMLXpXg3C4q8soAlvuOeG1lvY=
+github.com/line/wasmvm v1.1.1-0.11.1.0.20230417075905-90cc1950b4a1/go.mod h1:Lq3FVvi/rb+OOlTxqtcqcao2GGESQ4hUpuXMcjdJbco=
 github.com/lucasjones/reggen v0.0.0-20180717132126-cdb49ff09d77/go.mod h1:5ELEyG+X8f+meRWHuqUOewBOhvHkl7M76pdGEansxW4=
 github.com/lufeee/execinquery v1.2.1/go.mod h1:EC7DrEKView09ocscGHC+apXMIaorh4xqSxS/dy8SbM=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=

--- a/x/wasm/keeper/api.go
+++ b/x/wasm/keeper/api.go
@@ -43,34 +43,6 @@ func (a cosmwasmAPIImpl) canonicalAddress(human string) ([]byte, uint64, error) 
 	return bz, gasMultiplier.ToWasmVMGas(4), err
 }
 
-func (a cosmwasmAPIImpl) getContractEnv(contractAddrStr string, inputSize uint64) (wasmvm.Env, *wasmvm.Cache, wasmvm.KVStore, wasmvm.Querier, wasmvm.GasMeter, []byte, uint64, uint64, error) {
-	contractAddr := sdk.MustAccAddressFromBech32(contractAddrStr)
-	contractInfo, codeInfo, prefixStore, err := a.keeper.contractInstance(*a.ctx, contractAddr)
-	if err != nil {
-		return wasmvm.Env{}, nil, nil, nil, nil, wasmvm.Checksum{}, 0, 0, err
-	}
-
-	gasMultiplier := a.keeper.getGasMultiplier(*a.ctx)
-
-	cache := a.keeper.wasmVM.GetCache()
-	if cache == nil {
-		panic("cannot found instance cache")
-	}
-
-	// prepare querier
-	querier := NewQueryHandler(*a.ctx, a.keeper.wasmVMQueryHandler, contractAddr, gasMultiplier)
-
-	// this gas cost is temporal value defined by
-	// https://github.com/line/lbm-sdk/runs/8150140720?check_suite_focus=true#step:5:483
-	// Before release, it is adjusted by benchmark taken in environment similar to the nodes.
-	gas := gasMultiplier.ToWasmVMGas(11)
-	instantiateCost := gasMultiplier.ToWasmVMGas(a.keeper.instantiateContractCosts(a.keeper.gasRegister, *a.ctx, a.keeper.IsPinnedCode(*a.ctx, contractInfo.CodeID), int(inputSize)))
-	wasmStore := types.NewWasmStore(prefixStore)
-	env := types.NewEnv(*a.ctx, contractAddr)
-
-	return env, cache, wasmStore, querier, a.keeper.gasMeter(*a.ctx), codeInfo.CodeHash, instantiateCost, gas, nil
-}
-
 // returns result, gas used, error
 func (a cosmwasmAPIImpl) callCallablePoint(contractAddrStr string, name []byte, args []byte, isReadonly bool, callstack []byte, gasLimit uint64) ([]byte, uint64, error) {
 	contractAddr := sdk.MustAccAddressFromBech32(contractAddrStr)
@@ -151,7 +123,6 @@ func (k Keeper) cosmwasmAPI(ctx sdk.Context) wasmvm.GoAPI {
 	return wasmvm.GoAPI{
 		HumanAddress:      x.humanAddress,
 		CanonicalAddress:  x.canonicalAddress,
-		GetContractEnv:    x.getContractEnv,
 		CallCallablePoint: x.callCallablePoint,
 		ValidateInterface: x.validateInterface,
 	}

--- a/x/wasm/keeper/api_test.go
+++ b/x/wasm/keeper/api_test.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -60,68 +59,6 @@ func TestAPICanonicalAddress(t *testing.T) {
 		_, gas, err := api.CanonicalAddress("invalid_address")
 		assert.Error(t, err)
 		assert.Equal(t, wasmtype.DefaultGasMultiplier*4, gas)
-	})
-}
-
-func TestAPIGetContractEnv(t *testing.T) {
-	// prepare ctx and keeper
-	ctx, keepers := CreateTestInput(t, false, SupportedFeatures, nil, nil)
-
-	// instantiate a number contract
-	numberWasm, err := ioutil.ReadFile("../testdata/number.wasm")
-	require.NoError(t, err)
-	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
-	creator := keepers.Faucet.NewFundedAccount(ctx, deposit...)
-	em := sdk.NewEventManager()
-	codeID, err := keepers.ContractKeeper.Create(ctx.WithEventManager(em), creator, numberWasm, nil)
-	require.NoError(t, err)
-	value := 42
-	initMsg := []byte(fmt.Sprintf(`{"value":%d}`, value))
-	contractAddr, _, err := keepers.ContractKeeper.Instantiate(ctx.WithEventManager(em), codeID, creator, nil, initMsg, "number", nil)
-	require.NoError(t, err)
-	msgLen := 101010
-
-	// prepare API
-	api := keepers.WasmKeeper.cosmwasmAPI(ctx)
-
-	t.Run("succeed", func(t *testing.T) {
-		// omitted value is MultipliedGasMeter. It is not tested here.
-		env, _, store, querier, _, _, instantiateCost, gas, err := api.GetContractEnv(contractAddr.String(), uint64(msgLen))
-
-		require.NoError(t, err)
-
-		assert.Equal(t, uint64(ctx.BlockHeight()), env.Block.Height)
-		assert.Equal(t, uint64(ctx.BlockTime().UnixNano()), env.Block.Time)
-		assert.Equal(t, ctx.ChainID(), env.Block.ChainID)
-		assert.Equal(t, contractAddr.String(), env.Contract.Address)
-
-		// "number" comes from https://github.com/line/cosmwasm/blob/d08b5a59115cc3d28f375b7425b902bfd1dac6a4/contracts/number/src/contract.rs#L9
-		assert.Equal(t, []byte{uint8(0), uint8(0), uint8(0), uint8(value)}, store.Get([]byte("number")))
-
-		queryMsg := []byte(`{"number":{}}`)
-		query := wasmvmtypes.QueryRequest{
-			Wasm: &wasmvmtypes.WasmQuery{
-				Smart: &wasmvmtypes.SmartQuery{
-					ContractAddr: contractAddr.String(),
-					Msg:          queryMsg,
-				},
-			},
-		}
-		queryResult, err := querier.Query(query, 10_000_000_000_000)
-		require.NoError(t, err)
-		assert.Equal(t, []byte(`{"value":42}`), queryResult)
-
-		expectedInstantiateCost := keepers.WasmKeeper.instantiateContractCosts(keepers.WasmKeeper.gasRegister, ctx, false, msgLen)
-		assert.Equal(t, wasmtype.DefaultGasMultiplier*expectedInstantiateCost, instantiateCost)
-
-		assert.Equal(t, wasmtype.DefaultGasMultiplier*11, gas)
-	})
-
-	t.Run("non-existed contract", func(t *testing.T) {
-		nonExistedContractAddr := "link1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqyu0w3p"
-		require.NotEqual(t, nonExistedContractAddr, contractAddr)
-		_, _, _, _, _, _, _, _, err := api.GetContractEnv(nonExistedContractAddr, uint64(msgLen))
-		require.Error(t, err)
 	})
 }
 

--- a/x/wasm/keeper/bench_test.go
+++ b/x/wasm/keeper/bench_test.go
@@ -92,15 +92,6 @@ func BenchmarkAPI(b *testing.B) {
 	addrBytes, err := sdk.AccAddressFromBech32(example.Contract.String())
 	require.NoError(b, err)
 
-	b.Run("GetContractEnv", func(b *testing.B) {
-		b.ReportAllocs()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_, _, _, _, _, _, _, _, err := api.GetContractEnv(addrStr, 0)
-			require.NoError(b, err)
-		}
-	})
-
 	b.Run("CanonicalAddress", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()


### PR DESCRIPTION
This PR removes old dynamic link features.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`getConractEnv` was used old dynamic link way.
It is not needed now and callCallablePoint is used instead of it.

This is a part of https://github.com/Finschia/cosmwasm/issues/273

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/Finschia/cosmwasm/issues/273

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is only removing and no need to test.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes. (not needed)
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not needed)