### PR TITLE
fix: stop wrap twice the response of handling non-plus wasm message in plus handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improvements
 
 ### Bug Fixes
+* [\#35](https://github.com/Finschia/wasmd/pull/35) stop wrap twice the response of handling non-plus wasm message in plus handler
 
 ### Breaking Changes
 

--- a/x/wasmplus/handler.go
+++ b/x/wasmplus/handler.go
@@ -29,8 +29,6 @@ func NewHandler(k wasmtypes.ContractOpsKeeper) sdk.Handler {
 				)
 				res, err = msgServer.StoreCodeAndInstantiateContract(sdk.WrapSDKContext(ctx), msg2)
 				return sdk.WrapServiceResult(ctx, res, err)
-			} else {
-				return nil, err
 			}
 		}
 		return res, err

--- a/x/wasmplus/handler.go
+++ b/x/wasmplus/handler.go
@@ -18,18 +18,21 @@ func NewHandler(k wasmtypes.ContractOpsKeeper) sdk.Handler {
 	wasmHandler := wasm.NewHandler(k)
 
 	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
-		var (
-			res proto.Message
-			err error
-		)
-		res, err = wasmHandler(ctx, msg)
+		res, err := wasmHandler(ctx, msg)
 		if err != nil && strings.Contains(err.Error(), "MsgStoreCodeAndInstantiateContract") {
 			// handle wasmplus service
 			msg2, ok := msg.(*types.MsgStoreCodeAndInstantiateContract)
 			if ok {
+				var (
+					res proto.Message
+					err error
+				)
 				res, err = msgServer.StoreCodeAndInstantiateContract(sdk.WrapSDKContext(ctx), msg2)
+				return sdk.WrapServiceResult(ctx, res, err)
+			} else {
+				return nil, err
 			}
 		}
-		return sdk.WrapServiceResult(ctx, res, err)
+		return res, err
 	}
 }


### PR DESCRIPTION
fixes the bug wrapping twice the response of handling non-plus wasm message in plus handler.

## Description
wasmplus's handler returned a response that is wrapped twice (too much) when a non-plus wasm message is given.
This PR

- stops wrapping the response too much.
- adds tests handling non-plus wasm messages in wasmplus handler
- improve how to branch the handling of message

<!--- Describe your changes in detail -->
closes: #33 
closes: #34 
closes: #32

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit-tests are added in this PR.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not needed)
