### PR TITLE
fix: delete unnecessary test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 ### Improvements
+* [\#43](https://github.com/Finschia/wasmd/pull/43) delete unnecessary test 
 
 ### Bug Fixes
 * [\#35](https://github.com/Finschia/wasmd/pull/35) stop wrap twice the response of handling non-plus wasm message in plus handler

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -1719,34 +1719,6 @@ func TestClearContractAdmin(t *testing.T) {
 	}
 }
 
-func TestExecuteManualInactiveContractFailure(t *testing.T) {
-	ctx, keepers := CreateTestInput(t, false, AvailableCapabilities)
-	keeper := keepers.ContractKeeper
-
-	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
-	topUp := sdk.NewCoins(sdk.NewInt64Coin("denom", 5000))
-	creator := keepers.Faucet.NewFundedRandomAccount(ctx, deposit...)
-	fred := keepers.Faucet.NewFundedRandomAccount(ctx, topUp...)
-
-	wasmCode, err := os.ReadFile("./testdata/hackatom.wasm")
-	require.NoError(t, err)
-
-	contractID, _, err := keeper.Create(ctx, creator, wasmCode, nil)
-	require.NoError(t, err)
-
-	_, _, bob := keyPubAddr()
-	initMsg := HackatomExampleInitMsg{
-		Verifier:    fred,
-		Beneficiary: bob,
-	}
-	initMsgBz, err := json.Marshal(initMsg)
-	require.NoError(t, err)
-
-	addr, _, err := keeper.Instantiate(ctx, contractID, creator, nil, initMsgBz, "demo contract 3", deposit)
-	require.NoError(t, err)
-	require.Equal(t, "link14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sgf2vn8", addr.String())
-}
-
 func TestPinCode(t *testing.T) {
 	ctx, keepers := CreateTestInput(t, false, AvailableCapabilities)
 	k := keepers.WasmKeeper


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #39 

This test was moved from finschia-sdk by https://github.com/Finschia/wasmd/pull/1 and added by https://github.com/Finschia/finschia-sdk/pull/470.

Previously, a function called `UpdateContractStatus()` was used in https://github.com/Finschia/finschia-sdk/pull/470/commits/bde56b916605921468938c26ebd3155da12c4d54, 
but it was removed from wasmd and has become a meaningless test.


Further checking with https://github.com/Finschia/wasmd/issues/48, active/inactive management is done by wasmplus.
https://github.com/Finschia/wasmd/blob/ff18c5493565b88eb8cb1ecb5312218168110173/x/wasmplus/keeper/contract_keeper.go#L15-L16

In the test I deleted, "contract status", which was checked by `UpdateContractStatus()`, is not used in the current wasmd, so there is no problem in deleting it.


And when you use `UpdateContractStatus()` before, you could only change it via gov proposal, which was tested, but is no longer necessary.

So I think it is better to remove this test.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I don't want to leave a meaningless test.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
