### PR TITLE
fix: fix dynamic link APIs do not panic with invalid bech32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [\#36](https://github.com/Finschia/wasmd/pull/36) separate `x/wasm` into `x/wasmplus` module of dynamiclink
 
 ### Bug Fixes
+* [\#57](https://github.com/Finschia/wasmd/pull/57) fix dynamic link APIs do not panic with invalid bech32
 * [\#35](https://github.com/Finschia/wasmd/pull/35) stop wrap twice the response of handling non-plus wasm message in plus handler
 
 ### Breaking Changes

--- a/init_single.sh
+++ b/init_single.sh
@@ -15,7 +15,7 @@ then
     mode="testnet"
 fi
 
-WASMD=${WASMD:-wasmplusd}
+WASMD=${WASMD:-wasmd}
 
 # initialize
 rm -rf ~/.wasmplusd

--- a/x/wasmplus/keeper/api.go
+++ b/x/wasmplus/keeper/api.go
@@ -19,7 +19,11 @@ type cosmwasmAPIGeneratorImpl struct {
 }
 
 func (a cosmwasmAPIImpl) callCallablePoint(contractAddrStr string, name []byte, args []byte, isReadonly bool, callstack []byte, gasLimit uint64) ([]byte, uint64, error) {
-	contractAddr := sdk.MustAccAddressFromBech32(contractAddrStr)
+	contractAddr, err := sdk.AccAddressFromBech32(contractAddrStr)
+
+	if err != nil {
+		return nil, 0, fmt.Errorf("specified callee address is invalid: %s", err)
+	}
 
 	if a.keeper.IsInactiveContract(*a.ctx, contractAddr) {
 		return nil, 0, fmt.Errorf("called contract cannot be executed")
@@ -29,7 +33,11 @@ func (a cosmwasmAPIImpl) callCallablePoint(contractAddrStr string, name []byte, 
 }
 
 func (a cosmwasmAPIImpl) validateInterface(contractAddrStr string, expectedInterface []byte) ([]byte, uint64, error) {
-	contractAddr := sdk.MustAccAddressFromBech32(contractAddrStr)
+	contractAddr, err := sdk.AccAddressFromBech32(contractAddrStr)
+
+	if err != nil {
+		return nil, 0, fmt.Errorf("specified contract address is invalid: %s", err)
+	}
 
 	if a.keeper.IsInactiveContract(*a.ctx, contractAddr) {
 		return nil, 0, fmt.Errorf("try to validate a contract cannot be executed")

--- a/x/wasmplus/keeper/api_test.go
+++ b/x/wasmplus/keeper/api_test.go
@@ -227,6 +227,18 @@ func TestCallCallablePoint(t *testing.T) {
 		// reset inactive contracts
 		keepers.WasmKeeper.deleteInactiveContract(ctx, contractAddr)
 	})
+
+	t.Run("fail with invalid callee address", func(t *testing.T) {
+		argsEv := [][]byte{eventsInBin}
+		argsEvBin, err := json.Marshal(argsEv)
+		require.NoError(t, err)
+		name := "add_events_dyn"
+		nameBin, err := json.Marshal(name)
+		require.NoError(t, err)
+		invalidAddr := "invalidAddr"
+		_, _, err = api.CallCallablePoint(invalidAddr, nameBin, argsEvBin, false, callstackBin, gasLimit)
+		assert.ErrorContains(t, err, "specified callee address is invalid")
+	})
 }
 
 func TestValidateDynamicLinkInterface(t *testing.T) {
@@ -287,5 +299,13 @@ func TestValidateDynamicLinkInterface(t *testing.T) {
 
 		// reset inactive contracts
 		keepers.WasmKeeper.deleteInactiveContract(ctx, contractAddr)
+	})
+
+	t.Run("fail with invalid contract address", func(t *testing.T) {
+		validInterface := []byte(`[{"name":"add_event_dyn","ty":{"params":["I32","I32","I32"],"results":[]}},{"name":"add_events_dyn","ty":{"params":["I32","I32"],"results":[]}},{"name":"add_attribute_dyn","ty":{"params":["I32","I32","I32"],"results":[]}},{"name":"add_attributes_dyn","ty":{"params":["I32","I32"],"results":[]}}]`)
+		invalidAddr := "invalidAddr"
+		_, _, err = api.ValidateInterface(invalidAddr, validInterface)
+
+		assert.ErrorContains(t, err, "specified contract address is invalid")
 	})
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #55

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Though addresses given to dynamic link API are specified by contracts (users), it panics when address is invalid bech32 string. It should not panic and should handle it as an error.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By unit tests.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not needed)
