### PR TITLE
fix: fill ContractHistory querier result's Updated field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Improvements
 
 ### Bug Fixes
+* [\#62](https://github.com/Finschia/wasmd/pull/62) fill ContractHistory querier result's Updated field
 * [\#52](https://github.com/Finschia/wasmd/pull/52) fix cli_test error of wasmplus and add cli_test ci
 
 ### Breaking Changes

--- a/x/wasm/client/testutil/query.go
+++ b/x/wasm/client/testutil/query.go
@@ -394,6 +394,8 @@ func (s *IntegrationTestSuite) TestGetCmdGetContractHistory() {
 
 	codeID, err := strconv.ParseUint(s.codeID, 10, 64)
 	s.Require().NoError(err)
+	s.Require().True(s.setupHeight > 0)
+	codeUpdateHeight := uint64(s.setupHeight)
 
 	testCases := map[string]struct {
 		args     []string
@@ -410,7 +412,7 @@ func (s *IntegrationTestSuite) TestGetCmdGetContractHistory() {
 					{
 						Operation: types.ContractCodeHistoryOperationTypeInit,
 						CodeID:    codeID,
-						Updated:   nil,
+						Updated:   &types.AbsoluteTxPosition{BlockHeight: codeUpdateHeight, TxIndex: 0},
 						Msg:       []byte(fmt.Sprintf("{\"verifier\":\"%s\",\"beneficiary\":\"%s\"}", s.verifier, s.beneficiary)),
 					},
 				},

--- a/x/wasm/keeper/legacy_querier.go
+++ b/x/wasm/keeper/legacy_querier.go
@@ -144,10 +144,6 @@ func queryCodeList(ctx sdk.Context, keeper types.ViewKeeper) ([]types.CodeInfoRe
 //nolint:unparam
 func queryContractHistory(ctx sdk.Context, contractAddr sdk.AccAddress, keeper types.ViewKeeper) ([]types.ContractCodeHistoryEntry, error) {
 	history := keeper.GetContractHistory(ctx, contractAddr)
-	// redact response
-	for i := range history {
-		history[i].Updated = nil
-	}
 	return history, nil
 }
 

--- a/x/wasm/keeper/legacy_querier_test.go
+++ b/x/wasm/keeper/legacy_querier_test.go
@@ -233,12 +233,13 @@ func TestLegacyQueryContractHistory(t *testing.T) {
 			srcHistory: []types.ContractCodeHistoryEntry{{
 				Operation: types.ContractCodeHistoryOperationTypeGenesis,
 				CodeID:    firstCodeID,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 				Msg:       []byte(`"init message"`),
 			}},
 			expContent: []types.ContractCodeHistoryEntry{{
 				Operation: types.ContractCodeHistoryOperationTypeGenesis,
 				CodeID:    firstCodeID,
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 				Msg:       []byte(`"init message"`),
 			}},
 		},
@@ -246,30 +247,33 @@ func TestLegacyQueryContractHistory(t *testing.T) {
 			srcHistory: []types.ContractCodeHistoryEntry{{
 				Operation: types.ContractCodeHistoryOperationTypeInit,
 				CodeID:    firstCodeID,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 				Msg:       []byte(`"init message"`),
 			}, {
 				Operation: types.ContractCodeHistoryOperationTypeMigrate,
 				CodeID:    2,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 3, TxIndex: 4},
 				Msg:       []byte(`"migrate message 1"`),
 			}, {
 				Operation: types.ContractCodeHistoryOperationTypeMigrate,
 				CodeID:    3,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 5, TxIndex: 6},
 				Msg:       []byte(`"migrate message 2"`),
 			}},
 			expContent: []types.ContractCodeHistoryEntry{{
 				Operation: types.ContractCodeHistoryOperationTypeInit,
 				CodeID:    firstCodeID,
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 				Msg:       []byte(`"init message"`),
 			}, {
 				Operation: types.ContractCodeHistoryOperationTypeMigrate,
 				CodeID:    2,
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 3, TxIndex: 4},
 				Msg:       []byte(`"migrate message 1"`),
 			}, {
 				Operation: types.ContractCodeHistoryOperationTypeMigrate,
 				CodeID:    3,
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 5, TxIndex: 6},
 				Msg:       []byte(`"migrate message 2"`),
 			}},
 		},
@@ -278,7 +282,7 @@ func TestLegacyQueryContractHistory(t *testing.T) {
 			srcHistory: []types.ContractCodeHistoryEntry{{
 				Operation: types.ContractCodeHistoryOperationTypeGenesis,
 				CodeID:    firstCodeID,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 				Msg:       []byte(`"init message"`),
 			}},
 			expContent: []types.ContractCodeHistoryEntry{},

--- a/x/wasm/keeper/querier.go
+++ b/x/wasm/keeper/querier.go
@@ -68,7 +68,6 @@ func (q grpcQuerier) ContractHistory(c context.Context, req *types.QueryContract
 			if err := q.cdc.Unmarshal(value, &e); err != nil {
 				return false, err
 			}
-			e.Updated = nil // redact
 			r = append(r, e)
 		}
 		return true, nil

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -330,7 +330,7 @@ func TestQueryContractHistory(t *testing.T) {
 			srcHistory: []types.ContractCodeHistoryEntry{{
 				Operation: types.ContractCodeHistoryOperationTypeGenesis,
 				CodeID:    firstCodeID,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 				Msg:       []byte(`"init message"`),
 			}},
 			req: types.QueryContractHistoryRequest{Address: myContractBech32Addr},
@@ -338,23 +338,24 @@ func TestQueryContractHistory(t *testing.T) {
 				Operation: types.ContractCodeHistoryOperationTypeGenesis,
 				CodeID:    firstCodeID,
 				Msg:       []byte(`"init message"`),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 			}},
 		},
 		"response with multiple entries": {
 			srcHistory: []types.ContractCodeHistoryEntry{{
 				Operation: types.ContractCodeHistoryOperationTypeInit,
 				CodeID:    firstCodeID,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 				Msg:       []byte(`"init message"`),
 			}, {
 				Operation: types.ContractCodeHistoryOperationTypeMigrate,
 				CodeID:    2,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 3, TxIndex: 4},
 				Msg:       []byte(`"migrate message 1"`),
 			}, {
 				Operation: types.ContractCodeHistoryOperationTypeMigrate,
 				CodeID:    3,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 5, TxIndex: 6},
 				Msg:       []byte(`"migrate message 2"`),
 			}},
 			req: types.QueryContractHistoryRequest{Address: myContractBech32Addr},
@@ -362,26 +363,29 @@ func TestQueryContractHistory(t *testing.T) {
 				Operation: types.ContractCodeHistoryOperationTypeInit,
 				CodeID:    firstCodeID,
 				Msg:       []byte(`"init message"`),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 			}, {
 				Operation: types.ContractCodeHistoryOperationTypeMigrate,
 				CodeID:    2,
 				Msg:       []byte(`"migrate message 1"`),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 3, TxIndex: 4},
 			}, {
 				Operation: types.ContractCodeHistoryOperationTypeMigrate,
 				CodeID:    3,
 				Msg:       []byte(`"migrate message 2"`),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 5, TxIndex: 6},
 			}},
 		},
 		"with pagination offset": {
 			srcHistory: []types.ContractCodeHistoryEntry{{
 				Operation: types.ContractCodeHistoryOperationTypeInit,
 				CodeID:    firstCodeID,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 				Msg:       []byte(`"init message"`),
 			}, {
 				Operation: types.ContractCodeHistoryOperationTypeMigrate,
 				CodeID:    2,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 3, TxIndex: 4},
 				Msg:       []byte(`"migrate message 1"`),
 			}},
 			req: types.QueryContractHistoryRequest{
@@ -394,18 +398,19 @@ func TestQueryContractHistory(t *testing.T) {
 				Operation: types.ContractCodeHistoryOperationTypeMigrate,
 				CodeID:    2,
 				Msg:       []byte(`"migrate message 1"`),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 3, TxIndex: 4},
 			}},
 		},
 		"with pagination limit": {
 			srcHistory: []types.ContractCodeHistoryEntry{{
 				Operation: types.ContractCodeHistoryOperationTypeInit,
 				CodeID:    firstCodeID,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 				Msg:       []byte(`"init message"`),
 			}, {
 				Operation: types.ContractCodeHistoryOperationTypeMigrate,
 				CodeID:    2,
-				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 3, TxIndex: 4},
 				Msg:       []byte(`"migrate message 1"`),
 			}},
 			req: types.QueryContractHistoryRequest{
@@ -418,6 +423,7 @@ func TestQueryContractHistory(t *testing.T) {
 				Operation: types.ContractCodeHistoryOperationTypeInit,
 				CodeID:    firstCodeID,
 				Msg:       []byte(`"init message"`),
+				Updated:   &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2},
 			}},
 		},
 		"unknown contract address": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Without this PR, `ContractHistory` always returns its' `Updated` field as nil.
This PR cherry-picks https://github.com/CosmWasm/wasmd/pull/1089/commits/9cbf64d967fa1298929b242defe9e4253ad82a21 and fixes `ContractHistory` legacy querier to fill the Updated field.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not needed)
