### PR TITLE
refactor: refactor test cases for Params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [\#73](https://github.com/Finschia/wasmd/pull/73) test: add the check for expPaginationTotal
 * [\#72](https://github.com/Finschia/wasmd/pull/72) add pagination next key test in ContractHistory
 * [\#75](https://github.com/Finschia/wasmd/pull/75) test: add the test case for InactiveContract
-* [\#69](https://github.com/Finschia/wasmd/pull/69) add test cases to Params
+* [\#69](https://github.com/Finschia/wasmd/pull/69) refactor: add test cases to Params
 
 ### Bug Fixes
 * [\#62](https://github.com/Finschia/wasmd/pull/62) fill ContractHistory querier result's Updated field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * [\#73](https://github.com/Finschia/wasmd/pull/73) test: add the check for expPaginationTotal
 * [\#72](https://github.com/Finschia/wasmd/pull/72) add pagination next key test in ContractHistory
 * [\#75](https://github.com/Finschia/wasmd/pull/75) test: add the test case for InactiveContract
-* [\#69](https://github.com/Finschia/wasmd/pull/69) refactor: add test cases to Params
+* [\#69](https://github.com/Finschia/wasmd/pull/69) refactor: refactor test cases for Params
 
 ### Bug Fixes
 * [\#62](https://github.com/Finschia/wasmd/pull/62) fill ContractHistory querier result's Updated field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [\#63](https://github.com/Finschia/wasmd/pull/63) add event checking to TestStoreCode
 * [\#65](https://github.com/Finschia/wasmd/pull/65) add test cases for empty request in each function
 * [\#66](https://github.com/Finschia/wasmd/pull/66) add test cases for invalid pagination key in some functions
+* [\#66](https://github.com/Finschia/wasmd/pull/69) add test cases to Params
 
 ### Bug Fixes
 * [\#52](https://github.com/Finschia/wasmd/pull/52) fix cli_test error of wasmplus and add cli_test ci

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -876,6 +876,10 @@ func TestQueryParams(t *testing.T) {
 		expParams types.Params
 		expErr    error
 	}{
+		"allowEverybody(DefaultParams)": {
+			setParams: types.DefaultParams(),
+			expParams: types.DefaultParams(),
+		},
 		"allowNobody": {
 			setParams: types.Params{
 				CodeUploadAccess:             types.AllowNobody,

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -873,21 +873,14 @@ func TestQueryParams(t *testing.T) {
 
 	specs := map[string]struct {
 		setParams types.Params
-		srcQuery  *types.QueryParamsRequest
 		expParams types.Params
 		expErr    error
 	}{
-		"with empty request": {
-			setParams: types.DefaultParams(),
-			srcQuery:  nil,
-			expParams: types.DefaultParams(),
-		},
 		"allowNobody": {
 			setParams: types.Params{
 				CodeUploadAccess:             types.AllowNobody,
 				InstantiateDefaultPermission: types.AccessTypeNobody,
 			},
-			srcQuery: &types.QueryParamsRequest{},
 			expParams: types.Params{
 				CodeUploadAccess:             types.AllowNobody,
 				InstantiateDefaultPermission: types.AccessTypeNobody,
@@ -896,9 +889,10 @@ func TestQueryParams(t *testing.T) {
 	}
 	for msg, spec := range specs {
 		t.Run(msg, func(t *testing.T) {
+			xCtx, _ := ctx.CacheContext()
 			keeper.SetParams(ctx, spec.setParams)
 
-			paramsResponse, err = q.Params(sdk.WrapSDKContext(ctx), spec.srcQuery)
+			paramsResponse, err = q.Params(sdk.WrapSDKContext(xCtx), &types.QueryParamsRequest{})
 
 			require.NoError(t, err)
 			require.NotNil(t, paramsResponse)

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -890,7 +890,7 @@ func TestQueryParams(t *testing.T) {
 	for msg, spec := range specs {
 		t.Run(msg, func(t *testing.T) {
 			xCtx, _ := ctx.CacheContext()
-			keeper.SetParams(ctx, spec.setParams)
+			keeper.SetParams(xCtx, spec.setParams)
 
 			paramsResponse, err = q.Params(sdk.WrapSDKContext(xCtx), &types.QueryParamsRequest{})
 

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -866,11 +866,6 @@ func TestQueryParams(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, paramsResponse)
 
-	defaultParams := types.DefaultParams()
-
-	require.Equal(t, paramsResponse.Params.CodeUploadAccess, defaultParams.CodeUploadAccess)
-	require.Equal(t, paramsResponse.Params.InstantiateDefaultPermission, defaultParams.InstantiateDefaultPermission)
-
 	specs := map[string]struct {
 		setParams types.Params
 		expParams types.Params

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -798,31 +798,51 @@ func TestQueryPinnedCodes(t *testing.T) {
 }
 
 func TestQueryParams(t *testing.T) {
-	ctx, keepers := CreateTestInput(t, false, AvailableCapabilities)
-	keeper := keepers.WasmKeeper
+	specs := map[string]struct {
+		srcPermission types.AccessType
+		expInstConf   types.AccessConfig
+	}{
+		"default": {
+			srcPermission: types.DefaultParams().InstantiateDefaultPermission,
+			expInstConf:   types.AllowEverybody,
+		},
+		"everybody": {
+			srcPermission: types.AccessTypeEverybody,
+			expInstConf:   types.AllowEverybody,
+		},
+		"nobody": {
+			srcPermission: types.AccessTypeNobody,
+			expInstConf:   types.AllowNobody,
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			ctx, keepers := CreateTestInput(t, false, AvailableCapabilities)
+			keeper := keepers.WasmKeeper
 
-	q := Querier(keeper)
+			q := Querier(keeper)
 
-	paramsResponse, err := q.Params(sdk.WrapSDKContext(ctx), &types.QueryParamsRequest{})
-	require.NoError(t, err)
-	require.NotNil(t, paramsResponse)
+			paramsResponse, err := q.Params(sdk.WrapSDKContext(ctx), &types.QueryParamsRequest{})
+			require.NoError(t, err)
+			require.NotNil(t, paramsResponse)
 
-	defaultParams := types.DefaultParams()
+			defaultParams := types.DefaultParams()
 
-	require.Equal(t, paramsResponse.Params.CodeUploadAccess, defaultParams.CodeUploadAccess)
-	require.Equal(t, paramsResponse.Params.InstantiateDefaultPermission, defaultParams.InstantiateDefaultPermission)
+			require.Equal(t, paramsResponse.Params.CodeUploadAccess, defaultParams.CodeUploadAccess)
+			require.Equal(t, paramsResponse.Params.InstantiateDefaultPermission, defaultParams.InstantiateDefaultPermission)
 
-	keeper.SetParams(ctx, types.Params{
-		CodeUploadAccess:             types.AllowNobody,
-		InstantiateDefaultPermission: types.AccessTypeNobody,
-	})
+			keeper.SetParams(ctx, types.Params{
+				CodeUploadAccess:             spec.expInstConf,
+				InstantiateDefaultPermission: spec.srcPermission,
+			})
 
-	paramsResponse, err = q.Params(sdk.WrapSDKContext(ctx), &types.QueryParamsRequest{})
-	require.NoError(t, err)
-	require.NotNil(t, paramsResponse)
-
-	require.Equal(t, paramsResponse.Params.CodeUploadAccess, types.AllowNobody)
-	require.Equal(t, paramsResponse.Params.InstantiateDefaultPermission, types.AccessTypeNobody)
+			paramsResponse, err = q.Params(sdk.WrapSDKContext(ctx), &types.QueryParamsRequest{})
+			require.NoError(t, err)
+			require.NotNil(t, paramsResponse)
+			require.Equal(t, spec.expInstConf, paramsResponse.Params.CodeUploadAccess)
+			require.Equal(t, spec.srcPermission, paramsResponse.Params.InstantiateDefaultPermission)
+		})
+	}
 }
 
 func TestQueryCodeInfo(t *testing.T) {

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -862,10 +862,6 @@ func TestQueryParams(t *testing.T) {
 
 	q := Querier(keeper)
 
-	paramsResponse, err := q.Params(sdk.WrapSDKContext(ctx), &types.QueryParamsRequest{})
-	require.NoError(t, err)
-	require.NotNil(t, paramsResponse)
-
 	specs := map[string]struct {
 		setParams types.Params
 		expParams types.Params
@@ -891,7 +887,7 @@ func TestQueryParams(t *testing.T) {
 			xCtx, _ := ctx.CacheContext()
 			keeper.SetParams(xCtx, spec.setParams)
 
-			paramsResponse, err = q.Params(sdk.WrapSDKContext(xCtx), &types.QueryParamsRequest{})
+			paramsResponse, err := q.Params(sdk.WrapSDKContext(xCtx), &types.QueryParamsRequest{})
 
 			require.NoError(t, err)
 			require.NotNil(t, paramsResponse)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
### Params: TestQueryParams
Add a test case because we have not tested for Params.

```
// QueryParamsResponse is the response type for the Query/Params RPC method.
message QueryParamsResponse {
  // params defines the parameters of the module.
  Params params = 1 [ (gogoproto.nullable) = false ];
}
```

spec:
https://github.com/Finschia/wasmd/blob/main/proto/cosmwasm/wasm/v1/query.proto#L63

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not needed)
