### PR TITLE
fix: use ctx cache in msg server integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Bug Fixes
 * [\#35](https://github.com/Finschia/wasmd/pull/35) stop wrap twice the response of handling non-plus wasm message in plus handler
+* [\#77](https://github.com/Finschia/wasmd/pull/77) use ctx cache in msg server integration test
 
 ### Document Updates
 * [\#44](https://github.com/Finschia/wasmd/pull/44) update notice

--- a/x/wasm/keeper/msg_server_integration_test.go
+++ b/x/wasm/keeper/msg_server_integration_test.go
@@ -89,6 +89,7 @@ func TestInstantiateContract(t *testing.T) {
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
+			xCtx, _ := ctx.CacheContext()
 			// setup
 			_, _, sender := testdata.KeyTestPubAddr()
 			msg := types.MsgStoreCodeFixture(func(m *types.MsgStoreCode) {
@@ -98,7 +99,7 @@ func TestInstantiateContract(t *testing.T) {
 			})
 
 			// store code
-			rsp, err := wasmApp.MsgServiceRouter().Handler(msg)(ctx, msg)
+			rsp, err := wasmApp.MsgServiceRouter().Handler(msg)(xCtx, msg)
 			require.NoError(t, err)
 			var result types.MsgStoreCodeResponse
 			require.NoError(t, wasmApp.AppCodec().Unmarshal(rsp.Data, &result))
@@ -112,7 +113,7 @@ func TestInstantiateContract(t *testing.T) {
 				Msg:    []byte(`{}`),
 				Funds:  sdk.Coins{},
 			}
-			rsp, err = wasmApp.MsgServiceRouter().Handler(msgInstantiate)(ctx, msgInstantiate)
+			rsp, err = wasmApp.MsgServiceRouter().Handler(msgInstantiate)(xCtx, msgInstantiate)
 
 			//then
 			if spec.expErr {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the bug in integration test when testing multiple specs in one test function.
In this pr, we use ctx.CacheContext() instead of ctx.
Fix the bug caused by #70 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.(not needed)
- [ ] I have updated the documentation accordingly.(not needed)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`(not needed)
