### PR TITLE
test: add an integration test for TestExecuteContract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [\#78](https://github.com/Finschia/wasmd/pull/78) add the check for TestMigrateContract
 * [\#69](https://github.com/Finschia/wasmd/pull/69) refactor: refactor test cases for Params
 * [\#71](https://github.com/Finschia/wasmd/pull/71) add test cases in ContractsByCode
+* [\#87](https://github.com/Finschia/wasmd/pull/87) add an integration test for TestExecuteContract 
 
 ### Bug Fixes
 * [\#62](https://github.com/Finschia/wasmd/pull/62) fill ContractHistory querier result's Updated field

--- a/x/wasm/keeper/msg_server_integration_test.go
+++ b/x/wasm/keeper/msg_server_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	_ "embed"
 	"encoding/hex"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -15,11 +16,15 @@ import (
 	sdk "github.com/Finschia/finschia-sdk/types"
 
 	"github.com/Finschia/wasmd/app"
+	"github.com/Finschia/wasmd/x/wasm/keeper"
 	"github.com/Finschia/wasmd/x/wasm/types"
 )
 
 //go:embed testdata/reflect.wasm
 var wasmContract []byte
+
+//go:embed testdata/hackatom.wasm
+var hackatomContract []byte
 
 func TestStoreCode(t *testing.T) {
 	wasmApp := app.Setup(false)
@@ -136,6 +141,109 @@ func TestInstantiateContract(t *testing.T) {
 			assert.Contains(t, string(rsp.Data), string(events[1].Attributes[0].Value))
 			assert.Equal(t, "code_id", string(events[1].Attributes[1].Key))
 			assert.Equal(t, "1", string(events[1].Attributes[1].Value))
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestExecuteContract(t *testing.T) {
+	wasmApp := app.Setup(false)
+	ctx := wasmApp.BaseApp.NewContext(false, tmproto.Header{Time: time.Now()})
+
+	var (
+		myAddress       sdk.AccAddress = make([]byte, types.ContractAddrLen)
+		_, _, otherAddr                = testdata.KeyTestPubAddr()
+	)
+
+	specs := map[string]struct {
+		addr   string
+		expErr bool
+	}{
+		"adress can execute a contract": {
+			addr:   myAddress.String(),
+			expErr: false,
+		},
+		"other address cannot execute a contract": {
+			addr:   otherAddr.String(),
+			expErr: true,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			xCtx, _ := ctx.CacheContext()
+			// setup
+			_, _, sender := testdata.KeyTestPubAddr()
+			msg := types.MsgStoreCodeFixture(func(m *types.MsgStoreCode) {
+				m.WASMByteCode = hackatomContract
+				m.Sender = sender.String()
+			})
+
+			// store code
+			rsp, err := wasmApp.MsgServiceRouter().Handler(msg)(xCtx, msg)
+			require.NoError(t, err)
+			var storeCodeResponse types.MsgStoreCodeResponse
+			require.NoError(t, wasmApp.AppCodec().Unmarshal(rsp.Data, &storeCodeResponse))
+
+			// instantiate contract
+			initMsg := keeper.HackatomExampleInitMsg{
+				Verifier:    myAddress,
+				Beneficiary: otherAddr,
+			}
+			initMsgBz, err := json.Marshal(initMsg)
+			require.NoError(t, err)
+			msgInstantiate := &types.MsgInstantiateContract{
+				Sender: spec.addr,
+				Admin:  myAddress.String(),
+				CodeID: storeCodeResponse.CodeID,
+				Label:  "test",
+				Msg:    initMsgBz,
+				Funds:  sdk.Coins{},
+			}
+			rsp, err = wasmApp.MsgServiceRouter().Handler(msgInstantiate)(xCtx, msgInstantiate)
+			require.NoError(t, err)
+			var instantiateResponse types.MsgInstantiateContractResponse
+			require.NoError(t, wasmApp.AppCodec().Unmarshal(rsp.Data, &instantiateResponse))
+
+			msgExecuteContract := &types.MsgExecuteContract{
+				Sender:   spec.addr,
+				Msg:      []byte(`{"release":{}}`),
+				Contract: instantiateResponse.Address,
+				Funds:    sdk.Coins{},
+			}
+			rsp, err = wasmApp.MsgServiceRouter().Handler(msgExecuteContract)(xCtx, msgExecuteContract)
+
+			// then
+			if spec.expErr {
+				require.Error(t, err)
+				return
+			}
+
+			// check event
+			events := rsp.Events
+			assert.Equal(t, 4, len(events))
+			assert.Equal(t, "message", events[0].Type)
+			assert.Equal(t, 2, len(events[0].Attributes))
+			assert.Equal(t, "module", string(events[0].Attributes[0].Key))
+			assert.Equal(t, "wasm", string(events[0].Attributes[0].Value))
+			assert.Equal(t, "sender", string(events[0].Attributes[1].Key))
+			assert.Equal(t, myAddress.String(), string(events[0].Attributes[1].Value))
+			assert.Equal(t, "execute", events[1].Type)
+			assert.Equal(t, 1, len(events[1].Attributes))
+			assert.Equal(t, "_contract_address", string(events[1].Attributes[0].Key))
+			assert.Equal(t, instantiateResponse.Address, string(events[1].Attributes[0].Value))
+			assert.Equal(t, "wasm", events[2].Type)
+			assert.Equal(t, 3, len(events[2].Attributes))
+			assert.Equal(t, "_contract_address", string(events[2].Attributes[0].Key))
+			assert.Equal(t, instantiateResponse.Address, string(events[2].Attributes[0].Value))
+			assert.Equal(t, "action", string(events[2].Attributes[1].Key))
+			assert.Equal(t, "release", string(events[2].Attributes[1].Value))
+			assert.Equal(t, "destination", string(events[2].Attributes[2].Key))
+			assert.Equal(t, "wasm-hackatom", events[3].Type)
+			assert.Equal(t, "_contract_address", string(events[3].Attributes[0].Key))
+			assert.Equal(t, instantiateResponse.Address, string(events[3].Attributes[0].Value))
+			assert.Equal(t, "action", string(events[3].Attributes[1].Key))
+			assert.Equal(t, "release", string(events[3].Attributes[1].Value))
 
 			require.NoError(t, err)
 		})

--- a/x/wasm/keeper/msg_server_integration_test.go
+++ b/x/wasm/keeper/msg_server_integration_test.go
@@ -146,6 +146,7 @@ func TestInstantiateContract(t *testing.T) {
 		})
 	}
 }
+
 func TestInstantiateContract2(t *testing.T) {
 	wasmApp := app.Setup(false)
 	ctx := wasmApp.BaseApp.NewContext(false, tmproto.Header{Time: time.Now()})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
### TestExecuteContract
This PR adds an integration test for ExecuteContract.

This test is written for a test that depends on the hackatom contract.
The events added by hackatom contract are as follows.

https://github.com/Finschia/cosmwasm/blob/d86b54571ef7861964548241da6d8cbf6f77090f/contracts/hackatom/src/contract.rs#L94-L97

The destination address was not available on the msg_server, so I did not compare `events[2].Attributes[2].Value`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
