### PR TITLE
fix: fill ContractInfo result's Updated field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Bug Fixes
 * [\#62](https://github.com/Finschia/wasmd/pull/62) fill ContractHistory querier result's Updated field
 * [\#52](https://github.com/Finschia/wasmd/pull/52) fix cli_test error of wasmplus and add cli_test ci
+* [\#89](https://github.com/Finschia/wasmd/pull/89) fill ContractInfo querier result's Updated field
 
 ### Breaking Changes
 

--- a/x/wasm/client/testutil/query.go
+++ b/x/wasm/client/testutil/query.go
@@ -140,6 +140,8 @@ func (s *IntegrationTestSuite) TestGetCmdGetContractInfo() {
 
 	codeID, err := strconv.ParseUint(s.codeID, 10, 64)
 	s.Require().NoError(err)
+	s.Require().True(s.setupHeight > 0)
+	codeUpdateHeight := uint64(s.setupHeight)
 
 	testCases := map[string]struct {
 		args     []string
@@ -158,7 +160,7 @@ func (s *IntegrationTestSuite) TestGetCmdGetContractInfo() {
 					Creator:   val.Address.String(),
 					Admin:     val.Address.String(),
 					Label:     "TestContract",
-					Created:   nil,
+					Created:   &types.AbsoluteTxPosition{BlockHeight: codeUpdateHeight, TxIndex: 0},
 					IBCPortID: "",
 					Extension: nil,
 				},

--- a/x/wasm/keeper/querier.go
+++ b/x/wasm/keeper/querier.go
@@ -256,8 +256,6 @@ func queryContractInfo(ctx sdk.Context, addr sdk.AccAddress, keeper types.ViewKe
 	if info == nil {
 		return nil, types.ErrNotFound
 	}
-	// redact the Created field (just used for sorting, not part of public API)
-	info.Created = nil
 	return &types.QueryContractInfoResponse{
 		Address:      addr.String(),
 		ContractInfo: *info,

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -856,20 +856,16 @@ func TestQueryContractInfo(t *testing.T) {
 			src:    &types.QueryContractInfoRequest{Address: contractAddr.String()},
 			stored: types.ContractInfoFixture(),
 			expRsp: &types.QueryContractInfoResponse{
-				Address: contractAddr.String(),
-				ContractInfo: types.ContractInfoFixture(func(info *types.ContractInfo) {
-					info.Created = nil // not returned on queries
-				}),
+				Address:      contractAddr.String(),
+				ContractInfo: types.ContractInfoFixture(),
 			},
 		},
 		"with extension": {
 			src:    &types.QueryContractInfoRequest{Address: contractAddr.String()},
 			stored: types.ContractInfoFixture(myExtension),
 			expRsp: &types.QueryContractInfoResponse{
-				Address: contractAddr.String(),
-				ContractInfo: types.ContractInfoFixture(myExtension, func(info *types.ContractInfo) {
-					info.Created = nil // not returned on queries
-				}),
+				Address:      contractAddr.String(),
+				ContractInfo: types.ContractInfoFixture(myExtension),
 			},
 		},
 		"not found": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Without this PR, `ContractInfo` always returns its' `Updated` field as nil.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly. (not need)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not need)
