### PR TITLE
fix: delete output in TestQueryContractsByCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Bug Fixes
 * [\#62](https://github.com/Finschia/wasmd/pull/62) fill ContractHistory querier result's Updated field
 * [\#52](https://github.com/Finschia/wasmd/pull/52) fix cli_test error of wasmplus and add cli_test ci
+* [\#90](https://github.com/Finschia/wasmd/pull/90) delete output in TestQueryContractsByCode
 
 ### Breaking Changes
 

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -306,7 +306,6 @@ func TestQueryContractsByCode(t *testing.T) {
 		adminAddr := contract.CreatorAddr
 		label := "demo contract to query"
 		contractAddr, _, err := keepers.ContractKeeper.Instantiate(ctx, contract.CodeID, contract.CreatorAddr, adminAddr, initMsgBz, label, initialAmount)
-		fmt.Println(contract.CodeID)
 		require.NoError(t, err)
 		return contractAddr
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
delete output in TestQueryContractsByCode, caused by #71 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes. (not need)
- [ ] I have updated the documentation accordingly. (not need)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not need)
