### PR TITLE
test: add a test case to verify ContractInfo gets correct IBCPortID

### DIFF
--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -845,6 +845,9 @@ func TestQueryContractInfo(t *testing.T) {
 		myExt.TotalDeposit = nil
 		info.SetExtension(&myExt)
 	}
+	withIBCPort := func(info *types.ContractInfo) {
+		info.IBCPortID = "fooPort"
+	}
 	specs := map[string]struct {
 		src    *types.QueryContractInfoRequest
 		stored types.ContractInfo
@@ -865,6 +868,14 @@ func TestQueryContractInfo(t *testing.T) {
 			expRsp: &types.QueryContractInfoResponse{
 				Address:      contractAddr.String(),
 				ContractInfo: types.ContractInfoFixture(myExtension),
+			},
+		},
+		"with IBCPortID": {
+			src:    &types.QueryContractInfoRequest{Address: contractAddr.String()},
+			stored: types.ContractInfoFixture(withIBCPort),
+			expRsp: &types.QueryContractInfoResponse{
+				Address:      contractAddr.String(),
+				ContractInfo: types.ContractInfoFixture(withIBCPort),
 			},
 		},
 		"not found": {


### PR DESCRIPTION
This PR adds a test case to verify ContractInfo gets correct IBCPortID

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not needed)
