### PR TITLE
fix: move helper method out of generated file

### DIFF
--- a/x/wasm/types/types.go
+++ b/x/wasm/types/types.go
@@ -386,3 +386,14 @@ func isSubset(super, sub []string) bool {
 	}
 	return matches == len(sub)
 }
+
+// AllAuthorizedAddresses returns the list of authorized addresses. Can be empty.
+func (a AccessConfig) AllAuthorizedAddresses() []string {
+	switch a.Permission {
+	case AccessTypeAnyOfAddresses:
+		return a.Addresses
+	case AccessTypeOnlyAddress:
+		return []string{a.Address}
+	}
+	return []string{}
+}

--- a/x/wasm/types/types.pb.go
+++ b/x/wasm/types/types.pb.go
@@ -1572,17 +1572,6 @@ func (m *AccessConfig) Unmarshal(dAtA []byte) error {
 	return nil
 }
 
-// si
-func (a AccessConfig) AllAuthorizedAddresses() []string {
-	switch a.Permission {
-	case AccessTypeAnyOfAddresses:
-		return a.Addresses
-	case AccessTypeOnlyAddress:
-		return []string{a.Address}
-	}
-	return []string{}
-}
-
 func (m *Params) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With #46 , the helper method are written in auto generated files and will be removed during `proto-gen`.
This PR cherry-picks https://github.com/CosmWasm/wasmd/pull/1089/commits/8918e284b2885bfb3dfe90c68339b42debd32b5d.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.(no need)
- [ ] I have updated the documentation accordingly.(no need)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`(no need)
