### PR TITLE
docs: add clarifications to the order of list response in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 ### Document Updates
 * [\#54](https://github.com/Finschia/wasmd/pull/54) add documentation about errors (codespace and codes)
 * [\#92](https://github.com/Finschia/wasmd/pull/92) modify links in x/wasmplus README.md
+* [\#103](https://github.com/Finschia/wasmd/pull/103) add clarifications to the order of list response in query
 
 
 ## [v0.1.4](https://github.com/Finschia/wasmd/releases/tag/v0.1.4) - 2023.05.22

--- a/docs/proto/proto-docs.md
+++ b/docs/proto/proto-docs.md
@@ -985,7 +985,7 @@ Query/AllContractState RPC method
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `models` | [Model](#cosmwasm.wasm.v1.Model) | repeated |  |
+| `models` | [Model](#cosmwasm.wasm.v1.Model) | repeated | return in alphabetical order of the state's keys |
 | `pagination` | [cosmos.base.query.v1beta1.PageResponse](#cosmos.base.query.v1beta1.PageResponse) |  | pagination defines the pagination in the response. |
 
 
@@ -1047,7 +1047,7 @@ QueryCodesResponse is the response type for the Query/Codes RPC method
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `code_infos` | [CodeInfoResponse](#cosmwasm.wasm.v1.CodeInfoResponse) | repeated |  |
+| `code_infos` | [CodeInfoResponse](#cosmwasm.wasm.v1.CodeInfoResponse) | repeated | return in the order of code_id |
 | `pagination` | [cosmos.base.query.v1beta1.PageResponse](#cosmos.base.query.v1beta1.PageResponse) |  | pagination defines the pagination in the response. |
 
 
@@ -1081,7 +1081,7 @@ Query/ContractHistory RPC method
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `entries` | [ContractCodeHistoryEntry](#cosmwasm.wasm.v1.ContractCodeHistoryEntry) | repeated |  |
+| `entries` | [ContractCodeHistoryEntry](#cosmwasm.wasm.v1.ContractCodeHistoryEntry) | repeated | return in the order of contract execution |
 | `pagination` | [cosmos.base.query.v1beta1.PageResponse](#cosmos.base.query.v1beta1.PageResponse) |  | pagination defines the pagination in the response. |
 
 
@@ -1148,7 +1148,7 @@ Query/ContractsByCode RPC method
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `contracts` | [string](#string) | repeated | contracts are a set of contract addresses |
+| `contracts` | [string](#string) | repeated | contracts are a set of contract addresses return in the order of instantiation |
 | `pagination` | [cosmos.base.query.v1beta1.PageResponse](#cosmos.base.query.v1beta1.PageResponse) |  | pagination defines the pagination in the response. |
 
 
@@ -1206,7 +1206,7 @@ Query/PinnedCodes RPC method
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `code_ids` | [uint64](#uint64) | repeated |  |
+| `code_ids` | [uint64](#uint64) | repeated | return in the order of code_id |
 | `pagination` | [cosmos.base.query.v1beta1.PageResponse](#cosmos.base.query.v1beta1.PageResponse) |  | pagination defines the pagination in the response. |
 
 

--- a/docs/proto/proto-docs.md
+++ b/docs/proto/proto-docs.md
@@ -1081,7 +1081,7 @@ Query/ContractHistory RPC method
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `entries` | [ContractCodeHistoryEntry](#cosmwasm.wasm.v1.ContractCodeHistoryEntry) | repeated | return in the order of contract execution |
+| `entries` | [ContractCodeHistoryEntry](#cosmwasm.wasm.v1.ContractCodeHistoryEntry) | repeated | return in the order of timestamps according to contract updates |
 | `pagination` | [cosmos.base.query.v1beta1.PageResponse](#cosmos.base.query.v1beta1.PageResponse) |  | pagination defines the pagination in the response. |
 
 
@@ -1148,7 +1148,7 @@ Query/ContractsByCode RPC method
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `contracts` | [string](#string) | repeated | contracts are a set of contract addresses return in the order of instantiation |
+| `contracts` | [string](#string) | repeated | contracts are a set of contract addresses. return in the order of timestamps according to instantiation or migration |
 | `pagination` | [cosmos.base.query.v1beta1.PageResponse](#cosmos.base.query.v1beta1.PageResponse) |  | pagination defines the pagination in the response. |
 
 

--- a/docs/proto/proto-docs.md
+++ b/docs/proto/proto-docs.md
@@ -1081,7 +1081,7 @@ Query/ContractHistory RPC method
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `entries` | [ContractCodeHistoryEntry](#cosmwasm.wasm.v1.ContractCodeHistoryEntry) | repeated | return in the order of timestamps according to contract updates |
+| `entries` | [ContractCodeHistoryEntry](#cosmwasm.wasm.v1.ContractCodeHistoryEntry) | repeated | return in the order of timestamps according to when the contract was updated |
 | `pagination` | [cosmos.base.query.v1beta1.PageResponse](#cosmos.base.query.v1beta1.PageResponse) |  | pagination defines the pagination in the response. |
 
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Finschia/finschia-sdk v0.48.0-rc1
 	github.com/Finschia/ostracon v1.1.1
 	github.com/Finschia/wasmvm v1.1.1-0.11.2.0.20230418093236-ce70a3856778
+	github.com/cosmos/btcutil v1.0.5
 	github.com/cosmos/iavl v0.19.4
 	github.com/cosmos/ibc-go/v4 v4.3.1
 	github.com/dvsekhvalnov/jose2go v1.5.0
@@ -51,7 +52,6 @@ require (
 	github.com/coinbase/rosetta-sdk-go v0.8.3 // indirect
 	github.com/coinbase/rosetta-sdk-go/types v1.0.0 // indirect
 	github.com/confio/ics23/go v0.9.0 // indirect
-	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.12.2 // indirect

--- a/proto/cosmwasm/wasm/v1/query.proto
+++ b/proto/cosmwasm/wasm/v1/query.proto
@@ -97,7 +97,7 @@ message QueryContractHistoryRequest {
 // QueryContractHistoryResponse is the response type for the
 // Query/ContractHistory RPC method
 message QueryContractHistoryResponse {
-  // return in the order of contract execution
+  // return in the order of timestamps according to contract updates
   repeated ContractCodeHistoryEntry entries = 1
       [ (gogoproto.nullable) = false ];
   // pagination defines the pagination in the response.
@@ -115,8 +115,8 @@ message QueryContractsByCodeRequest {
 // QueryContractsByCodeResponse is the response type for the
 // Query/ContractsByCode RPC method
 message QueryContractsByCodeResponse {
-  // contracts are a set of contract addresses
-  // return in the order of instantiation
+  // contracts are a set of contract addresses.
+  // return in the order of timestamps according to instantiation or migration
   repeated string contracts = 1;
 
   // pagination defines the pagination in the response.

--- a/proto/cosmwasm/wasm/v1/query.proto
+++ b/proto/cosmwasm/wasm/v1/query.proto
@@ -97,7 +97,7 @@ message QueryContractHistoryRequest {
 // QueryContractHistoryResponse is the response type for the
 // Query/ContractHistory RPC method
 message QueryContractHistoryResponse {
-  // return in the order of timestamps according to contract updates
+  // return in the order of timestamps according to when the contract was updated
   repeated ContractCodeHistoryEntry entries = 1
       [ (gogoproto.nullable) = false ];
   // pagination defines the pagination in the response.

--- a/proto/cosmwasm/wasm/v1/query.proto
+++ b/proto/cosmwasm/wasm/v1/query.proto
@@ -97,6 +97,7 @@ message QueryContractHistoryRequest {
 // QueryContractHistoryResponse is the response type for the
 // Query/ContractHistory RPC method
 message QueryContractHistoryResponse {
+  // return in the order of contract execution
   repeated ContractCodeHistoryEntry entries = 1
       [ (gogoproto.nullable) = false ];
   // pagination defines the pagination in the response.
@@ -115,6 +116,7 @@ message QueryContractsByCodeRequest {
 // Query/ContractsByCode RPC method
 message QueryContractsByCodeResponse {
   // contracts are a set of contract addresses
+  // return in the order of instantiation
   repeated string contracts = 1;
 
   // pagination defines the pagination in the response.
@@ -133,6 +135,7 @@ message QueryAllContractStateRequest {
 // QueryAllContractStateResponse is the response type for the
 // Query/AllContractState RPC method
 message QueryAllContractStateResponse {
+  // return in alphabetical order of the state's keys
   repeated Model models = 1 [ (gogoproto.nullable) = false ];
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -207,6 +210,7 @@ message QueryCodesRequest {
 
 // QueryCodesResponse is the response type for the Query/Codes RPC method
 message QueryCodesResponse {
+  // return in the order of code_id
   repeated CodeInfoResponse code_infos = 1 [ (gogoproto.nullable) = false ];
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -222,6 +226,7 @@ message QueryPinnedCodesRequest {
 // QueryPinnedCodesResponse is the response type for the
 // Query/PinnedCodes RPC method
 message QueryPinnedCodesResponse {
+  // return in the order of code_id
   repeated uint64 code_ids = 1
       [ (gogoproto.nullable) = false, (gogoproto.customname) = "CodeIDs" ];
   // pagination defines the pagination in the response.

--- a/x/wasm/types/query.pb.go
+++ b/x/wasm/types/query.pb.go
@@ -177,6 +177,7 @@ var xxx_messageInfo_QueryContractHistoryRequest proto.InternalMessageInfo
 // QueryContractHistoryResponse is the response type for the
 // Query/ContractHistory RPC method
 type QueryContractHistoryResponse struct {
+	// return in the order of contract execution
 	Entries []ContractCodeHistoryEntry `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries"`
 	// pagination defines the pagination in the response.
 	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -270,6 +271,7 @@ var xxx_messageInfo_QueryContractsByCodeRequest proto.InternalMessageInfo
 // Query/ContractsByCode RPC method
 type QueryContractsByCodeResponse struct {
 	// contracts are a set of contract addresses
+	// return in the order of instantiation
 	Contracts []string `protobuf:"bytes,1,rep,name=contracts,proto3" json:"contracts,omitempty"`
 	// pagination defines the pagination in the response.
 	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -363,6 +365,7 @@ var xxx_messageInfo_QueryAllContractStateRequest proto.InternalMessageInfo
 // QueryAllContractStateResponse is the response type for the
 // Query/AllContractState RPC method
 type QueryAllContractStateResponse struct {
+	// return in alphabetical order of the state's keys
 	Models []Model `protobuf:"bytes,1,rep,name=models,proto3" json:"models"`
 	// pagination defines the pagination in the response.
 	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -768,6 +771,7 @@ var xxx_messageInfo_QueryCodesRequest proto.InternalMessageInfo
 
 // QueryCodesResponse is the response type for the Query/Codes RPC method
 type QueryCodesResponse struct {
+	// return in the order of code_id
 	CodeInfos []CodeInfoResponse `protobuf:"bytes,1,rep,name=code_infos,json=codeInfos,proto3" json:"code_infos"`
 	// pagination defines the pagination in the response.
 	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -859,6 +863,7 @@ var xxx_messageInfo_QueryPinnedCodesRequest proto.InternalMessageInfo
 // QueryPinnedCodesResponse is the response type for the
 // Query/PinnedCodes RPC method
 type QueryPinnedCodesResponse struct {
+	// return in the order of code_id
 	CodeIDs []uint64 `protobuf:"varint,1,rep,packed,name=code_ids,json=codeIds,proto3" json:"code_ids,omitempty"`
 	// pagination defines the pagination in the response.
 	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`

--- a/x/wasm/types/query.pb.go
+++ b/x/wasm/types/query.pb.go
@@ -177,7 +177,7 @@ var xxx_messageInfo_QueryContractHistoryRequest proto.InternalMessageInfo
 // QueryContractHistoryResponse is the response type for the
 // Query/ContractHistory RPC method
 type QueryContractHistoryResponse struct {
-	// return in the order of contract execution
+	// return in the order of timestamps according to contract updates
 	Entries []ContractCodeHistoryEntry `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries"`
 	// pagination defines the pagination in the response.
 	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -270,8 +270,8 @@ var xxx_messageInfo_QueryContractsByCodeRequest proto.InternalMessageInfo
 // QueryContractsByCodeResponse is the response type for the
 // Query/ContractsByCode RPC method
 type QueryContractsByCodeResponse struct {
-	// contracts are a set of contract addresses
-	// return in the order of instantiation
+	// contracts are a set of contract addresses.
+	// return in the order of timestamps according to instantiation or migration
 	Contracts []string `protobuf:"bytes,1,rep,name=contracts,proto3" json:"contracts,omitempty"`
 	// pagination defines the pagination in the response.
 	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`

--- a/x/wasm/types/query.pb.go
+++ b/x/wasm/types/query.pb.go
@@ -177,7 +177,7 @@ var xxx_messageInfo_QueryContractHistoryRequest proto.InternalMessageInfo
 // QueryContractHistoryResponse is the response type for the
 // Query/ContractHistory RPC method
 type QueryContractHistoryResponse struct {
-	// return in the order of timestamps according to contract updates
+	// return in the order of timestamps according to when the contract was updated
 	Entries []ContractCodeHistoryEntry `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries"`
 	// pagination defines the pagination in the response.
 	Pagination *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds clarifications to the order of list response in x/wasm query, which will make it easier for developers to understand the returned order.
closes: #91 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.(not need)
- [ ] I have updated the documentation accordingly.(not need)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`(not need)
