### PR TITLE
fix: declare dependency "buf.build/googleapis/googleapis"

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -9,6 +9,7 @@ deps:
   - buf.build/cosmos/cosmos-proto
   - buf.build/cosmos/cosmos-sdk:8cb30a2c4de74dc9bd8d260b1e75e176 #v0.46.x
   - buf.build/cosmos/gogo-proto
+  - buf.build/googleapis/googleapis
 breaking:
   use:
     - FILE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When you run `buf generate ./proto` in the root directory, you will receive the following warning: In fact, the dependency description is lacking.

```
WARN    bufimagebuild   File "cosmwasm/wasm/v1/query.proto" imports "google/api/annotations.proto", which is not found in your local files or direct dependencies, but is found in the transitive dependency "buf.build/googleapis/googleapis". Declare dependency "buf.build/googleapis/googleapis" in the deps key in buf.yaml.
```

This is a PR to correct this warning.
Declaring the dependency resolves the warning.



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md` (not needed)
- [ ] I have added tests to cover my changes. (not needed)
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not needed)
