### PR TITLE
 fix: version-up depending wasmvm to v1.1.1-0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bug Fixes
 
 ### Breaking Changes
-* [\#117](https://github.com/Finschia/wasmd/pull/117) version-up depending wasmvm
+* [\#117](https://github.com/Finschia/wasmd/pull/117) version-up depending wasmvm to v1.1.1-0.12.0
 
 ### Build, CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 ### Breaking Changes
+* [\#117](https://github.com/Finschia/wasmd/pull/117) version-up depending wasmvm
 
 ### Build, CI
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Finschia/finschia-sdk v0.48.0
 	github.com/Finschia/ostracon v1.1.2
-	github.com/Finschia/wasmvm v1.1.1-0.11.6
+	github.com/Finschia/wasmvm v1.1.1-0.12.0
 	github.com/cosmos/btcutil v1.0.5
 	github.com/cosmos/iavl v0.19.4
 	github.com/cosmos/ibc-go/v4 v4.3.1
@@ -148,5 +148,4 @@ replace (
 	// the following version across all dependencies.
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
-
 )

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/Finschia/ostracon v1.1.2 h1:JqP1RLTFHtCUr5I8njS698iJDz6YRXBsL06LnJy+8
 github.com/Finschia/ostracon v1.1.2/go.mod h1:eOAnifAmWFqCnB828FOlcrFzJ+Kt5Fgg+dswr7BSBDM=
 github.com/Finschia/r2ishiguro_vrf v0.1.2 h1:lDBz6NQMx1pw5I3End6xFmXpM//7KcmTr3Ka983e7v8=
 github.com/Finschia/r2ishiguro_vrf v0.1.2/go.mod h1:OHRtvzcJnfIrcJ0bvPNktJozRFAyZFuv56E9R3/qB+Y=
-github.com/Finschia/wasmvm v1.1.1-0.11.6 h1:Ae1XLQJKBltVBQugg6UwT8JBoSfN531L1Zc6CNgd1RA=
-github.com/Finschia/wasmvm v1.1.1-0.11.6/go.mod h1:NvaR6R52gFtNaKh+y/5fyUjS5Q2QfE8TJzv0bdSsWqQ=
+github.com/Finschia/wasmvm v1.1.1-0.12.0 h1:m+YXvFgE2vodYKJBkTAxAdfZsrdTDN0qA8s8d6cMesg=
+github.com/Finschia/wasmvm v1.1.1-0.12.0/go.mod h1:NvaR6R52gFtNaKh+y/5fyUjS5Q2QfE8TJzv0bdSsWqQ=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR version-ups wasmvm (this version contains CWA-2023-004 patch)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml` (not needed)
