### PR TITLE
feat: prevent fswap and fbridge module in Submessages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/Finschia/wasmd/compare/v0.3.0...HEAD)
 
 ### Features
+* [\#123](https://github.com/Finschia/wasmd/pull/123) prevent fswap and fbridge module in Submessages
 
 ### Improvements
 

--- a/x/wasm/keeper/msg_dispatcher.go
+++ b/x/wasm/keeper/msg_dispatcher.go
@@ -83,14 +83,14 @@ func (d MessageDispatcher) DispatchSubmessages(ctx sdk.Context, contractAddr sdk
 	var rsp []byte
 	for _, msg := range msgs {
 
-		// Prevent the use of fswap and fbridge module in Submessages
+		// Prevent the use of specific modules in Submessages
 		// https://github.com/Finschia/finschia-sdk/pull/1336, https://github.com/Finschia/finschia-sdk/pull/1340
 		if stargateMsg := msg.Msg.Stargate; stargateMsg != nil {
-			if strings.HasPrefix(stargateMsg.TypeURL, "/lbm.fswap.v1") {
-				return nil, sdkerrors.Wrap(types.ErrUnsupportedForContract, "fswap not supported by Stargate")
-			}
-			if strings.HasPrefix(stargateMsg.TypeURL, "/lbm.fbridge.v1") {
-				return nil, sdkerrors.Wrap(types.ErrUnsupportedForContract, "fbridge not supported by Stargate")
+			deniedModules := []string{"/lbm.fswap.v1", "/lbm.fbridge.v1"}
+			for _, moduleName := range deniedModules {
+				if strings.HasPrefix(stargateMsg.TypeURL, moduleName) {
+					return nil, sdkerrors.Wrap(types.ErrUnsupportedForContract, moduleName+" not supported by Stargate")
+				}
 			}
 		}
 

--- a/x/wasm/keeper/msg_dispatcher.go
+++ b/x/wasm/keeper/msg_dispatcher.go
@@ -87,10 +87,10 @@ func (d MessageDispatcher) DispatchSubmessages(ctx sdk.Context, contractAddr sdk
 		// https://github.com/Finschia/finschia-sdk/pull/1336, https://github.com/Finschia/finschia-sdk/pull/1340
 		if stargateMsg := msg.Msg.Stargate; stargateMsg != nil {
 			if strings.HasPrefix(stargateMsg.TypeURL, "/lbm.fswap.v1") {
-				return nil, sdkerrors.Wrap(types.ErrUnsupportedForContract, "fswap not supported of Stargate")
+				return nil, sdkerrors.Wrap(types.ErrUnsupportedForContract, "fswap not supported by Stargate")
 			}
 			if strings.HasPrefix(stargateMsg.TypeURL, "/lbm.fbridge.v1") {
-				return nil, sdkerrors.Wrap(types.ErrUnsupportedForContract, "fbridge not supported of Stargate")
+				return nil, sdkerrors.Wrap(types.ErrUnsupportedForContract, "fbridge not supported by Stargate")
 			}
 		}
 

--- a/x/wasm/keeper/msg_dispatcher.go
+++ b/x/wasm/keeper/msg_dispatcher.go
@@ -85,9 +85,13 @@ func (d MessageDispatcher) DispatchSubmessages(ctx sdk.Context, contractAddr sdk
 
 		// Prevent the use of fswap and fbridge module in Submessages
 		// https://github.com/Finschia/finschia-sdk/pull/1336, https://github.com/Finschia/finschia-sdk/pull/1340
-		if stargateMsg := msg.Msg.Stargate; stargateMsg != nil &&
-			(strings.Contains(stargateMsg.TypeURL, "lbm.fswap.v1") || strings.Contains(stargateMsg.TypeURL, "lbm.fbridge.v1")) {
-			return nil, sdkerrors.Wrap(types.ErrUnsupportedForContract, "fswap and fbridge not supported of Stargate")
+		if stargateMsg := msg.Msg.Stargate; stargateMsg != nil {
+			if strings.HasPrefix(stargateMsg.TypeURL, "/lbm.fswap.v1") {
+				return nil, sdkerrors.Wrap(types.ErrUnsupportedForContract, "fswap not supported of Stargate")
+			}
+			if strings.HasPrefix(stargateMsg.TypeURL, "/lbm.fbridge.v1") {
+				return nil, sdkerrors.Wrap(types.ErrUnsupportedForContract, "fbridge not supported of Stargate")
+			}
 		}
 
 		switch msg.ReplyOn {

--- a/x/wasm/keeper/msg_dispatcher_test.go
+++ b/x/wasm/keeper/msg_dispatcher_test.go
@@ -386,6 +386,14 @@ func TestDispatchSubmessages(t *testing.T) {
 				sdk.NewEvent("stargate-reply"),
 			},
 		},
+		"stargate msg with invalid fswap TypeURL": {
+			msgs:   []wasmvmtypes.SubMsg{{Msg: wasmvmtypes.CosmosMsg{Stargate: &wasmvmtypes.StargateMsg{TypeURL: "/lbm.fswap.v1.MsgSwapRequest"}}}},
+			expErr: true,
+		},
+		"stargate msg with invalid fbridge TypeURL": {
+			msgs:   []wasmvmtypes.SubMsg{{Msg: wasmvmtypes.CosmosMsg{Stargate: &wasmvmtypes.StargateMsg{TypeURL: "/lbm.fbridge.v1.MsgTransfer"}}}},
+			expErr: true,
+		},
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR implements a filtering mechanism for specific message types within Submessages. 
Specifically, messages related to `fswap` and `fbridge` are targeted by this filter, and any attempts to execute operations based on these message types will result in an error.

FYI: https://github.com/Finschia/finschia-sdk/pull/1336, https://github.com/Finschia/finschia-sdk/pull/1340

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmd/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/wasmd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`
